### PR TITLE
fix: refresh services page stylesheet cache

### DIFF
--- a/pages/services.html
+++ b/pages/services.html
@@ -19,7 +19,7 @@
     <link rel="icon" type="image/png" href="../assets/images/dynamic_bubble_logo.jpg">
     <meta name="theme-color" content="#ffffff">
 
-    <link rel="stylesheet" href="../css/styles.css?v=services-align-20260521">
+    <link rel="stylesheet" href="../css/styles.css?v=services-layout-final-20260521">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
     <link rel="stylesheet" href="../css/card-nav.css">
     <link rel="stylesheet" href="../css/text-type.css">


### PR DESCRIPTION
Updates the Services page stylesheet version so production browsers fetch the CSS containing the merged card alignment fix.